### PR TITLE
feat: patch for v3.2 release

### DIFF
--- a/src/periphery/contracts/misc/UiIncentiveDataProviderV3.sol
+++ b/src/periphery/contracts/misc/UiIncentiveDataProviderV3.sol
@@ -156,57 +156,11 @@ contract UiIncentiveDataProviderV3 is IUiIncentiveDataProviderV3 {
         vRewardsInformation
       );
 
-      // Get sTokens rewards information
-      IRewardsController sTokenIncentiveController = IRewardsController(
-        address(IncentivizedERC20(baseData.stableDebtTokenAddress).getIncentivesController())
-      );
+      // There's no sToken rewards since stable rate is deprecated
       RewardInfo[] memory sRewardsInformation;
-      if (address(sTokenIncentiveController) != address(0)) {
-        address[] memory sTokenRewardAddresses = sTokenIncentiveController.getRewardsByAsset(
-          baseData.stableDebtTokenAddress
-        );
-        sRewardsInformation = new RewardInfo[](sTokenRewardAddresses.length);
-        for (uint256 j = 0; j < sTokenRewardAddresses.length; ++j) {
-          RewardInfo memory rewardInformation;
-          rewardInformation.rewardTokenAddress = sTokenRewardAddresses[j];
-
-          (
-            rewardInformation.tokenIncentivesIndex,
-            rewardInformation.emissionPerSecond,
-            rewardInformation.incentivesLastUpdateTimestamp,
-            rewardInformation.emissionEndTimestamp
-          ) = sTokenIncentiveController.getRewardsData(
-            baseData.stableDebtTokenAddress,
-            rewardInformation.rewardTokenAddress
-          );
-
-          rewardInformation.precision = sTokenIncentiveController.getAssetDecimals(
-            baseData.stableDebtTokenAddress
-          );
-          rewardInformation.rewardTokenDecimals = IERC20Detailed(
-            rewardInformation.rewardTokenAddress
-          ).decimals();
-          rewardInformation.rewardTokenSymbol = IERC20Detailed(rewardInformation.rewardTokenAddress)
-            .symbol();
-
-          // Get price of reward token from Chainlink Proxy Oracle
-          rewardInformation.rewardOracleAddress = sTokenIncentiveController.getRewardOracle(
-            rewardInformation.rewardTokenAddress
-          );
-          rewardInformation.priceFeedDecimals = IEACAggregatorProxy(
-            rewardInformation.rewardOracleAddress
-          ).decimals();
-          rewardInformation.rewardPriceFeed = IEACAggregatorProxy(
-            rewardInformation.rewardOracleAddress
-          ).latestAnswer();
-
-          sRewardsInformation[j] = rewardInformation;
-        }
-      }
-
       reserveIncentiveData.sIncentiveData = IncentiveData(
-        baseData.stableDebtTokenAddress,
-        address(sTokenIncentiveController),
+        address(0),
+        address(0),
         sRewardsInformation
       );
     }
@@ -340,59 +294,6 @@ contract UiIncentiveDataProviderV3 is IUiIncentiveDataProviderV3 {
           baseData.variableDebtTokenAddress,
           address(aTokenIncentiveController),
           vUserRewardsInformation
-        );
-      }
-
-      // stable debt token
-      IRewardsController sTokenIncentiveController = IRewardsController(
-        address(IncentivizedERC20(baseData.stableDebtTokenAddress).getIncentivesController())
-      );
-      if (address(sTokenIncentiveController) != address(0)) {
-        // get all rewards information from the asset
-        address[] memory sTokenRewardAddresses = sTokenIncentiveController.getRewardsByAsset(
-          baseData.stableDebtTokenAddress
-        );
-        UserRewardInfo[] memory sUserRewardsInformation = new UserRewardInfo[](
-          sTokenRewardAddresses.length
-        );
-        for (uint256 j = 0; j < sTokenRewardAddresses.length; ++j) {
-          UserRewardInfo memory userRewardInformation;
-          userRewardInformation.rewardTokenAddress = sTokenRewardAddresses[j];
-
-          userRewardInformation.tokenIncentivesUserIndex = sTokenIncentiveController
-            .getUserAssetIndex(
-              user,
-              baseData.stableDebtTokenAddress,
-              userRewardInformation.rewardTokenAddress
-            );
-
-          userRewardInformation.userUnclaimedRewards = sTokenIncentiveController
-            .getUserAccruedRewards(user, userRewardInformation.rewardTokenAddress);
-          userRewardInformation.rewardTokenDecimals = IERC20Detailed(
-            userRewardInformation.rewardTokenAddress
-          ).decimals();
-          userRewardInformation.rewardTokenSymbol = IERC20Detailed(
-            userRewardInformation.rewardTokenAddress
-          ).symbol();
-
-          // Get price of reward token from Chainlink Proxy Oracle
-          userRewardInformation.rewardOracleAddress = sTokenIncentiveController.getRewardOracle(
-            userRewardInformation.rewardTokenAddress
-          );
-          userRewardInformation.priceFeedDecimals = IEACAggregatorProxy(
-            userRewardInformation.rewardOracleAddress
-          ).decimals();
-          userRewardInformation.rewardPriceFeed = IEACAggregatorProxy(
-            userRewardInformation.rewardOracleAddress
-          ).latestAnswer();
-
-          sUserRewardsInformation[j] = userRewardInformation;
-        }
-
-        userReservesIncentivesData[i].sTokenIncentivesUserData = UserIncentiveData(
-          baseData.stableDebtTokenAddress,
-          address(aTokenIncentiveController),
-          sUserRewardsInformation
         );
       }
     }

--- a/src/periphery/contracts/misc/UiPoolDataProviderV3.sol
+++ b/src/periphery/contracts/misc/UiPoolDataProviderV3.sol
@@ -72,10 +72,10 @@ contract UiPoolDataProviderV3 is IUiPoolDataProviderV3 {
       //the current variable borrow rate. Expressed in ray
       reserveData.variableBorrowRate = baseData.currentVariableBorrowRate;
       //the current stable borrow rate. Expressed in ray
-      reserveData.stableBorrowRate = baseData.currentStableBorrowRate;
+      reserveData.stableBorrowRate = 0;
       reserveData.lastUpdateTimestamp = baseData.lastUpdateTimestamp;
       reserveData.aTokenAddress = baseData.aTokenAddress;
-      reserveData.stableDebtTokenAddress = baseData.stableDebtTokenAddress;
+      reserveData.stableDebtTokenAddress = address(0);
       reserveData.variableDebtTokenAddress = baseData.variableDebtTokenAddress;
       //address of the interest rate strategy
       reserveData.interestRateStrategyAddress = baseData.interestRateStrategyAddress;
@@ -86,12 +86,11 @@ contract UiPoolDataProviderV3 is IUiPoolDataProviderV3 {
       reserveData.availableLiquidity = IERC20Detailed(reserveData.underlyingAsset).balanceOf(
         reserveData.aTokenAddress
       );
-      (
-        reserveData.totalPrincipalStableDebt,
-        ,
-        reserveData.averageStableRate,
-        reserveData.stableDebtLastUpdateTimestamp
-      ) = IStableDebtToken(reserveData.stableDebtTokenAddress).getSupplyData();
+
+      reserveData.totalPrincipalStableDebt = 0;
+      reserveData.averageStableRate = 0;
+      reserveData.stableDebtLastUpdateTimestamp = 0;
+
       reserveData.totalScaledVariableDebt = IVariableDebtToken(reserveData.variableDebtTokenAddress)
         .scaledTotalSupply();
 
@@ -237,15 +236,10 @@ contract UiPoolDataProviderV3 is IUiPoolDataProviderV3 {
         userReservesData[i].scaledVariableDebt = IVariableDebtToken(
           baseData.variableDebtTokenAddress
         ).scaledBalanceOf(user);
-        userReservesData[i].principalStableDebt = IStableDebtToken(baseData.stableDebtTokenAddress)
-          .principalBalanceOf(user);
-        if (userReservesData[i].principalStableDebt != 0) {
-          userReservesData[i].stableBorrowRate = IStableDebtToken(baseData.stableDebtTokenAddress)
-            .getUserStableRate(user);
-          userReservesData[i].stableBorrowLastUpdateTimestamp = IStableDebtToken(
-            baseData.stableDebtTokenAddress
-          ).getUserLastUpdated(user);
-        }
+
+        userReservesData[i].principalStableDebt = 0;
+        userReservesData[i].stableBorrowRate = 0;
+        userReservesData[i].stableBorrowLastUpdateTimestamp = 0;
       }
     }
 


### PR DESCRIPTION
- Patched data providers to be compatible with v3.1 and the v3.2 upgrade. Stable rate will be completely removed, and since all stable positions were migrated to variable, just hardcode the necessary values.

The intention would be to use these for a short time just to support the upgrade initially, and then migrate over to the data providers that support the new e-mode functionality.